### PR TITLE
feat(splashscreen): animate items staggered appearance after splashscreen

### DIFF
--- a/New Apps Test.xcodeproj/project.pbxproj
+++ b/New Apps Test.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0E4F468F2D137FDF00BB74F6 /* AnimatedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F468E2D137FDF00BB74F6 /* AnimatedBorder.swift */; };
 		0E4F46912D13832E00BB74F6 /* CalculateChallengeProgressUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46902D13832E00BB74F6 /* CalculateChallengeProgressUseCase.swift */; };
 		0E4F46932D13878500BB74F6 /* ChallengeInfoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46922D13878500BB74F6 /* ChallengeInfoCard.swift */; };
+		0E4F46952D13997B00BB74F6 /* SplashRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46942D13997B00BB74F6 /* SplashRootView.swift */; };
 		14374FB22B989FD500131332 /* New_Apps_TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14374FB12B989FD500131332 /* New_Apps_TestApp.swift */; };
 		14374FB62B989FD700131332 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14374FB52B989FD700131332 /* Assets.xcassets */; };
 		14374FBA2B989FD700131332 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14374FB92B989FD700131332 /* Preview Assets.xcassets */; };
@@ -124,6 +125,7 @@
 		0E4F468E2D137FDF00BB74F6 /* AnimatedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedBorder.swift; sourceTree = "<group>"; };
 		0E4F46902D13832E00BB74F6 /* CalculateChallengeProgressUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateChallengeProgressUseCase.swift; sourceTree = "<group>"; };
 		0E4F46922D13878500BB74F6 /* ChallengeInfoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeInfoCard.swift; sourceTree = "<group>"; };
+		0E4F46942D13997B00BB74F6 /* SplashRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashRootView.swift; sourceTree = "<group>"; };
 		14374FAE2B989FD500131332 /* New Apps Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "New Apps Test.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		14374FB12B989FD500131332 /* New_Apps_TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = New_Apps_TestApp.swift; sourceTree = "<group>"; };
 		14374FB52B989FD700131332 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 		0E4F464A2D1336C800BB74F6 /* Root */ = {
 			isa = PBXGroup;
 			children = (
+				0E4F46942D13997B00BB74F6 /* SplashRootView.swift */,
 				0E4F46732D133FF500BB74F6 /* Tab.swift */,
 				048E7C652C2F08B500B653F4 /* RootView.swift */,
 			);
@@ -696,6 +699,7 @@
 				0E35E76F2D123BC60003B857 /* PolaroidFrame.swift in Sources */,
 				0E4F46932D13878500BB74F6 /* ChallengeInfoCard.swift in Sources */,
 				0E35E7632D11E5430003B857 /* ParticipationState.swift in Sources */,
+				0E4F46952D13997B00BB74F6 /* SplashRootView.swift in Sources */,
 				14BEC9952C2DC39B009D8493 /* ThreadChatView.swift in Sources */,
 				0E4F46702D133CCE00BB74F6 /* InfiniteScrollModifier.swift in Sources */,
 				0E4F46712D133CCE00BB74F6 /* MasonryLayout.swift in Sources */,

--- a/New Apps Test/Core/New_Apps_TestApp.swift
+++ b/New Apps Test/Core/New_Apps_TestApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct New_Apps_TestApp: App {
     var body: some Scene {
         WindowGroup {
-            RootView()
+            SplashRootView()
         }
     }
 }

--- a/New Apps Test/Features/Challenge/Common/Views/Components/ChallengeInfoCard.swift
+++ b/New Apps Test/Features/Challenge/Common/Views/Components/ChallengeInfoCard.swift
@@ -59,7 +59,9 @@ struct ChallengeInfoCard: View {
     }
     
     private func setupTimer() {
-        animateBorder()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) {
+            animateBorder()
+        }
         
         borderTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
             animateBorder()

--- a/New Apps Test/Features/Challenge/TodayChallenge/Views/TodayChallengeView.swift
+++ b/New Apps Test/Features/Challenge/TodayChallenge/Views/TodayChallengeView.swift
@@ -7,9 +7,12 @@
 
 import SwiftUI
 
+import SwiftUI
+
 struct TodayChallengeView: View {
     @State private var viewModel: TodayChallengeViewModel
     @State private var showingSubmission = false
+    @State private var shouldAnimate = false
     
     let hapticManager: HapticManaging
     
@@ -41,6 +44,10 @@ struct TodayChallengeView: View {
         }
         .task {
             await viewModel.loadChallenge()
+            try? await Task.sleep(for: .seconds(2.6))
+            withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) {
+                shouldAnimate = true
+            }
         }
         .onDisappear {
             viewModel.stopTimer()
@@ -56,11 +63,15 @@ struct TodayChallengeView: View {
                 title: challenge.title,
                 description: challenge.description
             )
+            .offset(y: shouldAnimate ? 0 : 50)
+            .opacity(shouldAnimate ? 1 : 0)
             
             ParticipateButton(
                 hasParticipated: viewModel.hasParticipated,
                 showingSubmission: $showingSubmission
             )
+            .offset(y: shouldAnimate ? 0 : 50)
+            .opacity(shouldAnimate ? 1 : 0)
             
             ParticipationsGridView(
                 participations: viewModel.participations,

--- a/New Apps Test/Features/Root/SplashRootView.swift
+++ b/New Apps Test/Features/Root/SplashRootView.swift
@@ -1,0 +1,59 @@
+//
+//  SplashRootView.swift
+//  New Apps Test
+//
+//  Created by Kevin MACHADO on 19/12/2024.
+//
+
+
+import SwiftUI
+
+@MainActor
+final class SplashViewModel: ObservableObject {
+    enum TransitionPhase {
+        case initial
+        case transition
+        case completed
+    }
+    
+    @Published var phase: TransitionPhase = .initial
+    
+    func startTransition() async {
+        phase = .transition
+        
+        try? await Task.sleep(for: .seconds(1.2))
+        phase = .completed
+    }
+}
+
+struct SplashRootView: View {
+    @StateObject private var viewModel = SplashViewModel()
+    @State private var shouldShowSplash = true
+    
+    var body: some View {
+        ZStack {
+            RootView()
+                .opacity(viewModel.phase == .initial ? 0 : 1)
+            
+            if shouldShowSplash {
+                PolaroidCircleView(hapticManager: HapticManager.shared) {
+                    Task {
+                        await viewModel.startTransition()
+                    }
+                }
+                .transition(.opacity)
+            }
+        }
+        .onChange(of: viewModel.phase) { _, newPhase in
+            if newPhase == .completed {
+                withAnimation(.easeOut(duration: 0.3)) {
+                    shouldShowSplash = false
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashRootView()
+}


### PR DESCRIPTION
## 🎯 Purpose
Enhance the app's visual experience by creating a seamless transition between the splash screen and the main content. Items now appear one by one with a smooth animation that follows the splash screen's polaroid dispersion.

## 🔄 Changes
- Added `StaggeredAppearanceModifier` to handle grid items animations
- Synchronized animation timings between splash screen and main content
- Improved animation states management in `TodayChallengeView`
- Fine-tuned animation delays and durations for optimal visual flow
- Delayed border animation on `ChallengeInfoCard` to match overall timing

## 📱 Visual Impact
- Splash screen polaroids disperse upward
- Main content fades in with slight upward motion
- Border animation starts after content is visible

## 💡 Potential Improvements

For better maintainability and easier timing adjustments, we could extract all animation durations and delays into shared constants. This would make it easier to synchronize animations across components and update timings from a single source of truth. Example:

```swift
enum AnimationTimings {
    static let splashDuration: TimeInterval = 1.2
    static let contentDelay: TimeInterval = 2.6
    static let itemStaggerDelay: TimeInterval = 0.05
    static let borderDelay: TimeInterval = 2.8
    // etc...
}
```

This would make the coordination between splash screen, content appearance, and grid items animation more manageable and less error-prone when adjustments are needed.