### PR TITLE
feat(confetti): add confetti animation and haptic feedback on challenge completion

### DIFF
--- a/New Apps Test.xcodeproj/project.pbxproj
+++ b/New Apps Test.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		0E4F469E2D13A43900BB74F6 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F469D2D13A43900BB74F6 /* FloatingActionButton.swift */; };
 		0E4F46A02D13A46E00BB74F6 /* ChallengeDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F469F2D13A46E00BB74F6 /* ChallengeDetailsView.swift */; };
 		0E4F46A22D13ACC200BB74F6 /* CircleDetailCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46A12D13ACC200BB74F6 /* CircleDetailCardView.swift */; };
+		0E4F46A52D13B80900BB74F6 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46A42D13B80900BB74F6 /* ConfettiView.swift */; };
+		0E4F46A72D13B81000BB74F6 /* ConfettiFallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46A62D13B80F00BB74F6 /* ConfettiFallView.swift */; };
+		0E4F46A92D13B82900BB74F6 /* SuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4F46A82D13B82900BB74F6 /* SuccessView.swift */; };
 		14374FB22B989FD500131332 /* New_Apps_TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14374FB12B989FD500131332 /* New_Apps_TestApp.swift */; };
 		14374FB62B989FD700131332 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14374FB52B989FD700131332 /* Assets.xcassets */; };
 		14374FBA2B989FD700131332 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14374FB92B989FD700131332 /* Preview Assets.xcassets */; };
@@ -134,6 +137,9 @@
 		0E4F469D2D13A43900BB74F6 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		0E4F469F2D13A46E00BB74F6 /* ChallengeDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChallengeDetailsView.swift; sourceTree = "<group>"; };
 		0E4F46A12D13ACC200BB74F6 /* CircleDetailCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircleDetailCardView.swift; sourceTree = "<group>"; };
+		0E4F46A42D13B80900BB74F6 /* ConfettiView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
+		0E4F46A62D13B80F00BB74F6 /* ConfettiFallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfettiFallView.swift; sourceTree = "<group>"; };
+		0E4F46A82D13B82900BB74F6 /* SuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuccessView.swift; sourceTree = "<group>"; };
 		14374FAE2B989FD500131332 /* New Apps Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "New Apps Test.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		14374FB12B989FD500131332 /* New_Apps_TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = New_Apps_TestApp.swift; sourceTree = "<group>"; };
 		14374FB52B989FD700131332 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -202,6 +208,7 @@
 		048E7C712C32ACB000B653F4 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0E4F46A32D13B80000BB74F6 /* Confetti */,
 				0E35E76D2D123B660003B857 /* PolaroidCircle */,
 				14BEC9942C2DC39B009D8493 /* ThreadChatView.swift */,
 				048E7C6B2C2F3C6000B653F4 /* FriendsView.swift */,
@@ -491,6 +498,16 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		0E4F46A32D13B80000BB74F6 /* Confetti */ = {
+			isa = PBXGroup;
+			children = (
+				0E4F46A82D13B82900BB74F6 /* SuccessView.swift */,
+				0E4F46A62D13B80F00BB74F6 /* ConfettiFallView.swift */,
+				0E4F46A42D13B80900BB74F6 /* ConfettiView.swift */,
+			);
+			path = Confetti;
+			sourceTree = "<group>";
+		};
 		14374FA52B989FD500131332 = {
 			isa = PBXGroup;
 			children = (
@@ -714,11 +731,14 @@
 				0E35E76F2D123BC60003B857 /* PolaroidFrame.swift in Sources */,
 				0E4F46932D13878500BB74F6 /* ChallengeInfoCard.swift in Sources */,
 				0E35E7632D11E5430003B857 /* ParticipationState.swift in Sources */,
+				0E4F46A92D13B82900BB74F6 /* SuccessView.swift in Sources */,
 				0E4F46952D13997B00BB74F6 /* SplashRootView.swift in Sources */,
 				14BEC9952C2DC39B009D8493 /* ThreadChatView.swift in Sources */,
 				0E4F46702D133CCE00BB74F6 /* InfiniteScrollModifier.swift in Sources */,
+				0E4F46A72D13B81000BB74F6 /* ConfettiFallView.swift in Sources */,
 				0E4F46712D133CCE00BB74F6 /* MasonryLayout.swift in Sources */,
 				0E35E78D2D1301B20003B857 /* CustomSegmentedControl.swift in Sources */,
+				0E4F46A52D13B80900BB74F6 /* ConfettiView.swift in Sources */,
 				0E4F46862D1368DD00BB74F6 /* CircleView.swift in Sources */,
 				048E7C6C2C2F3C6000B653F4 /* FriendsView.swift in Sources */,
 				0E4F469C2D13A42100BB74F6 /* ExplorerViewModel.swift in Sources */,

--- a/New Apps Test/Features/Challenge/Common/Views/Components/TimeRemainingView.swift
+++ b/New Apps Test/Features/Challenge/Common/Views/Components/TimeRemainingView.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 
-import SwiftUI
-
 struct TimeRemainingView: View {
     let timeRemaining: String
     let progress: Double

--- a/New Apps Test/Views/Confetti/ConfettiFallView.swift
+++ b/New Apps Test/Views/Confetti/ConfettiFallView.swift
@@ -1,0 +1,42 @@
+//
+//  ConfettiFallView.swift
+//  New Apps Test
+//
+//  Created by Kevin MACHADO on 19/12/2024.
+//
+
+import SwiftUI
+import UIKit
+
+struct ConfettiFallView: View {
+    @Binding var isActive: Bool
+    private let hapticManager = HapticManager.shared
+    
+    var body: some View {
+        ZStack {
+            ForEach(0..<30, id: \.self) { i in
+                ConfettiView(
+                    color: Color.random,
+                    size: CGFloat.random(in: 8...16),
+                    xOffset: CGFloat.random(in: -UIScreen.main.bounds.width/2...UIScreen.main.bounds.width/2),
+                    duration: Double.random(in: 3...5)
+                )
+                .opacity(isActive ? 1 : 0)
+                .onAppear {
+                    if i % 3 == 0 {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * 0.1) {
+                            hapticManager.playImpact(intensity: CGFloat.random(in: 0.3...0.7))
+                        }
+                    }
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .onAppear {
+            if isActive {
+                hapticManager.playSequence(count: 5, interval: 0.15)
+            }
+        }
+    }
+}
+

--- a/New Apps Test/Views/Confetti/ConfettiView.swift
+++ b/New Apps Test/Views/Confetti/ConfettiView.swift
@@ -1,0 +1,34 @@
+//
+//  ConfettiView.swift
+//  New Apps Test
+//
+//  Created by Kevin MACHADO on 19/12/2024.
+//
+
+import SwiftUI
+
+struct ConfettiView: View {
+    let color: Color
+    let size: CGFloat
+    let xOffset: CGFloat
+    let duration: Double
+    
+    @State private var yOffset: CGFloat = -500
+    @State private var rotation: Double = 0
+    
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(width: size, height: size)
+            .rotationEffect(.degrees(rotation))
+            .offset(x: xOffset, y: yOffset)
+            .onAppear {
+                withAnimation(.easeInOut(duration: duration)) {
+                    yOffset = UIScreen.main.bounds.height + 100
+                }
+                withAnimation(.linear(duration: duration).repeatForever(autoreverses: false)) {
+                    rotation = 360
+                }
+            }
+    }
+}

--- a/New Apps Test/Views/Confetti/SuccessView.swift
+++ b/New Apps Test/Views/Confetti/SuccessView.swift
@@ -1,0 +1,50 @@
+//
+//  SuccessView.swift
+//  New Apps Test
+//
+//  Created by Kevin MACHADO on 19/12/2024.
+//
+
+import SwiftUI
+
+private struct SuccessView: View {
+    @State private var showConfetti = false
+    
+    var body: some View {
+        ZStack {
+            VStack {
+                Text("Défi Réussi !")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .padding()
+                
+                Button(action: {
+                    withAnimation {
+                        showConfetti = true
+                    }
+                    
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        withAnimation {
+                            showConfetti = false
+                        }
+                    }
+                }) {
+                    Text("Fêter !")
+                        .font(.headline)
+                        .padding()
+                        .background(Color.accentColor)
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }
+            
+            if showConfetti {
+                ConfettiFallView(isActive: $showConfetti)
+            }
+        }
+    }
+}
+
+#Preview {
+    SuccessView()
+}


### PR DESCRIPTION
### Summary
This PR introduces a confetti animation and haptic feedback that trigger when a user successfully completes a challenge in the `TodayChallengeView`. The addition enhances the user experience by visually and tactically celebrating the user's achievement.

### Changes
- Integrated `ConfettiFallView` to display confetti animations.
- Implemented haptic feedback using `HapticManager` for a more immersive effect.
- Updated `TodayChallengeView`:
  - Added a `showConfetti` state to control the confetti animation visibility.
  - Confetti and haptic feedback are triggered when the user submits a participation.
  - Automatically hides the confetti after 3 seconds to ensure a smooth experience.
- Ensured the confetti animation only plays once per challenge completion to avoid repeated triggers.

### Testing
- Verified that the confetti animation and haptic feedback are displayed only after completing a challenge.
- Tested the animation timing and ensured it disappears after 3 seconds.
- Confirmed that the `showConfetti` state resets correctly after each use.

### Screenshots
![Screenshot 2024-12-19 at 03 26 24](https://github.com/user-attachments/assets/5f1e6b93-553b-47c9-9c5b-e4f1b541dd88)